### PR TITLE
Links on left of footer route to BVT website + about page

### DIFF
--- a/src/app/Components/Footer.js
+++ b/src/app/Components/Footer.js
@@ -25,7 +25,7 @@ export default function Footer() {
         {sections.map((section, index) => (
           <div key={index} className="flex justify-center items-center">
             {section.title && (
-            <p className="font-light px-3 text-[#4B5E54] hover:underline">{section.title}</p>
+            <a key={index} href={section.href} className="font-light px-3 text-[#4B5E54] hover:underline">{section.title}</a>
             )}
           </div>
         ))}


### PR DESCRIPTION
## Images
![image](https://github.com/user-attachments/assets/2cae6d33-eb97-43da-8138-2d8bf2262f17)

## Changes
1. Bottom left links are active

## Purpose
To route the 'Bay Valley Tech' and 'Code Academy' on the footer to route to the BVT website and their about page respectively. Footer component should be complete and ready for use in other pages. 

## Approach
Now we have links to the website as well as the existing links to the social media. 

Closes #2 